### PR TITLE
Copy-to stream compliance

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
     'prefer-const': ['error'],
     'no-var': ['error'],
     'no-unused-vars': ['error', { args: 'none' }],
-    'prefer-destructuring': ['error'],
+    'prefer-destructuring': ['error', { array: false }],
     'no-useless-rename': ['error'],
   },
 }

--- a/copy-to.js
+++ b/copy-to.js
@@ -132,7 +132,7 @@ class CopyStreamQuery extends Transform {
 
     if (done) {
       this._detach()
-      this.push(null)
+      this.end()
       this._cleanup()
     }
 

--- a/test/copy-to.js
+++ b/test/copy-to.js
@@ -255,11 +255,30 @@ describe('copy-to', () => {
       describe('successful stream', () => {
         const successfulSql = `COPY (SELECT 1) TO STDOUT`
 
+        it("emits 1 'finish'", (done) => {
+          assertCopyToResult(successfulSql, (err, chunks, result, stream) => {
+            assert.ifError(err)
+            assert.equal(stream.emits['finish'].length, 1)
+            done()
+          })
+        })
+
         it("emits 1 'end'", (done) => {
           assertCopyToResult(successfulSql, (err, chunks, result, stream) => {
             assert.ifError(err)
             assert.equal(stream.emits['end'].length, 1)
             done()
+          })
+        })
+
+        it('works with finished()', (done) => {
+          createCopyToQuery(successfulSql, (client, copyToStream) => {
+            copyToStream.resume()
+            finished(copyToStream, (err) => {
+              assert.ifError(err)
+              client.end()
+              done()
+            })
           })
         })
 

--- a/test/copy-to.js
+++ b/test/copy-to.js
@@ -272,6 +272,7 @@ describe('copy-to', () => {
         })
 
         it('works with finished()', (done) => {
+          if (!finished) return done()
           createCopyToQuery(successfulSql, (client, copyToStream) => {
             copyToStream.resume()
             finished(copyToStream, (err) => {
@@ -283,6 +284,7 @@ describe('copy-to', () => {
         })
 
         it('works with pipeline()', (done) => {
+          if (!pipeline) return done()
           createCopyToQuery(successfulSql, (client, copyToStream) => {
             const pt = new PassThrough()
             pipeline(copyToStream, pt, (err) => {
@@ -322,6 +324,7 @@ describe('copy-to', () => {
         })
 
         it('works with finished()', (done) => {
+          if (!finished) return done()
           createCopyToQuery(syntaxErrorSql, (client, copyToStream) => {
             copyToStream.resume()
             finished(copyToStream, (err) => {
@@ -333,6 +336,7 @@ describe('copy-to', () => {
         })
 
         it('works with pipeline()', (done) => {
+          if (!pipeline) return done()
           createCopyToQuery(syntaxErrorSql, (client, copyToStream) => {
             pipeline(copyToStream, new PassThrough(), (err) => {
               assert.ok(err)
@@ -386,6 +390,7 @@ describe('copy-to', () => {
         })
 
         it('works with finished()', (done) => {
+          if (!finished) return done()
           createInternalErrorCopyToQuery((client, copyToStream) => {
             copyToStream.resume()
             finished(copyToStream, (err) => {
@@ -397,6 +402,7 @@ describe('copy-to', () => {
         })
 
         it('works with pipeline()', (done) => {
+          if (!pipeline) return done()
           createInternalErrorCopyToQuery((client, copyToStream) => {
             pipeline(copyToStream, new PassThrough(), (err) => {
               assert.ok(err)

--- a/test/copy-to.js
+++ b/test/copy-to.js
@@ -4,7 +4,7 @@ const assert = require('assert')
 
 const _ = require('lodash')
 const concat = require('concat-stream')
-const { Writable } = require('stream')
+const { Writable, finished, pipeline } = require('stream')
 const pg = require('pg')
 const { PassThrough } = require('stream')
 const { Transform } = require('stream')
@@ -30,23 +30,37 @@ describe('copy-to', () => {
       })
     }
 
-    function assertCopyToResult(sql, assertFn) {
+    function createCopyToQuery(sql, callback) {
       const client = getClient()
+      const copyToStream = client.query(copy(sql))
+      callback(client, copyToStream)
+    }
+
+    function spyOnEmitCalls(copyToStream) {
+      copyToStream.emits = {}
+      const realEmit = copyToStream.emit
+      copyToStream.emit = function () {
+        const [eventName, ...args] = arguments
+        if (!copyToStream.emits[eventName]) {
+          copyToStream.emits[eventName] = []
+        }
+        copyToStream.emits[eventName].push(args)
+        realEmit.apply(this, arguments)
+      }
+    }
+
+    function processCopyToStreamForAssertFn(client, copyToStream, assertFn) {
       const chunks = []
-      let hasCompleted = false
+      spyOnEmitCalls(copyToStream)
 
       function complete(err, chunks, result, stream) {
-        // both 'error' and 'end' events may fire, guard so assertFn is called only once
-        if (!hasCompleted) {
-          hasCompleted = true
-          client.end()
-          assertFn(err, chunks, result, stream)
-        }
+        client.end()
+        assertFn(err, chunks, result, stream)
       }
 
-      const copyToStream = client.query(copy(sql))
-
-      copyToStream.on('error', complete)
+      copyToStream.on('error', (err) => {
+        complete(err, chunks, null, copyToStream)
+      })
       copyToStream.on('end', () => {
         const result = Buffer.concat(chunks).toString()
         complete(null, chunks, result, copyToStream)
@@ -59,6 +73,12 @@ describe('copy-to', () => {
           },
         })
       )
+    }
+
+    function assertCopyToResult(sql, assertFn) {
+      createCopyToQuery(sql, (client, copyToStream) => {
+        processCopyToStreamForAssertFn(client, copyToStream, assertFn)
+      })
     }
 
     it('provides row count', (done) => {
@@ -97,9 +117,10 @@ describe('copy-to', () => {
       })
 
       setTimeout(() => {
-        executeSql(
-          "SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query ~ 'pg_sleep' AND NOT query ~ 'pg_cancel_backend'"
-        )
+        executeSql(`SELECT pg_cancel_backend(pid) 
+                      FROM pg_stat_activity 
+                     WHERE query ~ 'pg_sleep' 
+                       AND NOT query ~ 'pg_cancel_backend'`)
       }, 20)
     })
 
@@ -227,6 +248,144 @@ describe('copy-to', () => {
         assert(chunks.length > 1)
         assert.equal(result, `${'-'.repeat(fieldSize)}\n`)
         done()
+      })
+    })
+
+    describe('stream compliance', () => {
+      describe('successful stream', () => {
+        const successfulSql = `COPY (SELECT 1) TO STDOUT`
+
+        it("emits 1 'end'", (done) => {
+          assertCopyToResult(successfulSql, (err, chunks, result, stream) => {
+            assert.ifError(err)
+            assert.equal(stream.emits['end'].length, 1)
+            done()
+          })
+        })
+
+        it('works with pipeline()', (done) => {
+          createCopyToQuery(successfulSql, (client, copyToStream) => {
+            const pt = new PassThrough()
+            pipeline(copyToStream, pt, (err) => {
+              assert.ifError(err)
+              client.end()
+              done()
+            })
+          })
+        })
+      })
+
+      describe('erroneous stream (syntax error)', () => {
+        const syntaxErrorSql = `COPY (SELECT INVALID SYNTAX) TO STDOUT`
+
+        it("emits 0 'finish'", (done) => {
+          assertCopyToResult(syntaxErrorSql, (err, chunks, result, stream) => {
+            assert.ok(err)
+            assert.equal(stream.emits['finish'], undefined)
+            done()
+          })
+        })
+
+        it("emits 0 'end'", (done) => {
+          assertCopyToResult(syntaxErrorSql, (err, chunks, result, stream) => {
+            assert.ok(err)
+            assert.equal(stream.emits['end'], undefined)
+            done()
+          })
+        })
+
+        it("emits 1 'error'", (done) => {
+          assertCopyToResult(syntaxErrorSql, (err, chunks, result, stream) => {
+            assert.ok(err)
+            assert.equal(stream.emits['error'].length, 1)
+            done()
+          })
+        })
+
+        it('works with finished()', (done) => {
+          createCopyToQuery(syntaxErrorSql, (client, copyToStream) => {
+            copyToStream.resume()
+            finished(copyToStream, (err) => {
+              assert.ok(err)
+              client.end()
+              done()
+            })
+          })
+        })
+
+        it('works with pipeline()', (done) => {
+          createCopyToQuery(syntaxErrorSql, (client, copyToStream) => {
+            pipeline(copyToStream, new PassThrough(), (err) => {
+              assert.ok(err)
+              client.end()
+              done()
+            })
+          })
+        })
+      })
+
+      describe('erroneous stream (internal error)', () => {
+        function createInternalErrorCopyToQuery(callback) {
+          createCopyToQuery('COPY (SELECT pg_sleep(10)) TO STDOUT', callback)
+
+          setTimeout(() => {
+            executeSql(`SELECT pg_cancel_backend(pid) 
+                          FROM pg_stat_activity 
+                         WHERE query ~ 'pg_sleep' 
+                           AND NOT query ~ 'pg_cancel_backend'`)
+          }, 20)
+        }
+
+        function assertInternalErrorCopyToResult(assertFn) {
+          createInternalErrorCopyToQuery((client, copyToStream) => {
+            processCopyToStreamForAssertFn(client, copyToStream, assertFn)
+          })
+        }
+
+        it("emits 0 'finish'", (done) => {
+          assertInternalErrorCopyToResult((err, chunks, result, stream) => {
+            assert.ok(err)
+            assert.equal(stream.emits['finish'], undefined)
+            done()
+          })
+        })
+
+        it("emits 0 'end'", (done) => {
+          assertInternalErrorCopyToResult((err, chunks, result, stream) => {
+            assert.ok(err)
+            assert.equal(stream.emits['end'], undefined)
+            done()
+          })
+        })
+
+        it("emits 1 'error'", (done) => {
+          assertInternalErrorCopyToResult((err, chunks, result, stream) => {
+            assert.ok(err)
+            assert.equal(stream.emits['error'].length, 1)
+            done()
+          })
+        })
+
+        it('works with finished()', (done) => {
+          createInternalErrorCopyToQuery((client, copyToStream) => {
+            copyToStream.resume()
+            finished(copyToStream, (err) => {
+              assert.ok(err)
+              client.end()
+              done()
+            })
+          })
+        })
+
+        it('works with pipeline()', (done) => {
+          createInternalErrorCopyToQuery((client, copyToStream) => {
+            pipeline(copyToStream, new PassThrough(), (err) => {
+              assert.ok(err)
+              client.end()
+              done()
+            })
+          })
+        })
       })
     })
   })


### PR DESCRIPTION
While we're trying to comply with how streams work. How about tieing the loose ends in copy-to, as well:

Adds tests for emitted events in different cases
- successful case emits both 'finish' and 'end'
- error case doesn't emit 'end' or 'finish'
- both successful and error cases work with finished() and pipeline()

Fixes issue where succesful case didn't work with finished() - the 'finish' event wasn't emitted. This is caused by the fact that copy-to stream is not end()'ed by any party, but this.push(null) is used instead. Logically, this.push(null) should also cause Node to end the Transform stream, but currently this is not the case.